### PR TITLE
UI polish: liquid glass, counter animation, custom calendar

### DIFF
--- a/expense-tracker/src/components/AddModal.jsx
+++ b/expense-tracker/src/components/AddModal.jsx
@@ -1,11 +1,20 @@
 import { useState, useEffect, useRef } from 'react'
 import { today } from '../utils/format'
+import CalendarPicker from './CalendarPicker'
+
+const MONTHS_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+
+function formatDisplay(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  return `${d} ${MONTHS_SHORT[m - 1]} ${y}`
+}
 
 export default function AddModal({ open, onClose, onAdd }) {
   const [type, setType] = useState('expense')
   const [amount, setAmount] = useState('')
   const [date, setDate] = useState(today())
   const [description, setDescription] = useState('')
+  const [calOpen, setCalOpen] = useState(false)
   const amountRef = useRef(null)
 
   useEffect(() => {
@@ -14,6 +23,7 @@ export default function AddModal({ open, onClose, onAdd }) {
       setAmount('')
       setDate(today())
       setDescription('')
+      setCalOpen(false)
       setTimeout(() => amountRef.current?.focus(), 300)
     }
   }, [open])
@@ -26,40 +36,37 @@ export default function AddModal({ open, onClose, onAdd }) {
     onClose()
   }
 
-  const isIncome = type === 'income'
-
   return (
     <>
-      {/* Backdrop */}
+      {/* Backdrop — reduced opacity */}
       <div
-        className={`fixed inset-0 z-40 bg-black transition-opacity duration-300 ${
-          open ? 'opacity-60 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        className={`fixed inset-0 z-40 transition-opacity duration-300 ${
+          open ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
-        onClick={onClose}
+        style={{ background: 'rgba(0,0,0,0.35)' }}
+        onClick={() => { setCalOpen(false); onClose() }}
       />
 
-      {/* Sheet */}
+      {/* Sheet — glass modal */}
       <div
-        className={`fixed bottom-0 left-1/2 -translate-x-1/2 z-50 w-full max-w-[480px] bg-surface rounded-t-3xl px-6 pt-5 pb-10 transition-transform duration-300 ease-out ${
+        className={`glass-modal fixed bottom-0 left-1/2 -translate-x-1/2 z-50 w-full max-w-[480px] rounded-t-3xl px-6 pt-5 pb-10 transition-transform duration-300 ease-out ${
           open ? 'translate-y-0' : 'translate-y-full'
         }`}
-        style={{ maxHeight: '80vh', overflowY: 'auto' }}
+        style={{ maxHeight: '85vh', overflowY: 'auto' }}
+        onClick={() => setCalOpen(false)}
       >
         {/* Handle */}
-        <div className="w-10 h-1 bg-border rounded-full mx-auto mb-5" />
+        <div className="w-10 h-1 rounded-full mx-auto mb-5" style={{ background: 'rgba(255,255,255,0.15)' }} />
 
-        {/* Type toggle */}
-        <div className="flex bg-bg rounded-full p-1 gap-1 mb-6">
+        {/* Type toggle — liquid glass */}
+        <div className="flex glass rounded-full p-1 gap-1 mb-6">
           {['expense', 'income'].map(t => (
             <button
               key={t}
+              type="button"
               onClick={() => setType(t)}
               className={`flex-1 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
-                type === t
-                  ? t === 'income'
-                    ? 'bg-income text-black'
-                    : 'bg-expense text-black'
-                  : 'text-muted hover:text-white'
+                type === t ? 'glass-active text-white' : 'text-white/40 hover:text-white/70'
               }`}
             >
               {t.charAt(0).toUpperCase() + t.slice(1)}
@@ -67,11 +74,11 @@ export default function AddModal({ open, onClose, onAdd }) {
           ))}
         </div>
 
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} onClick={e => e.stopPropagation()}>
           {/* Amount */}
           <div className="mb-6 text-center">
             <div className="flex items-center justify-center gap-1">
-              <span className={`text-4xl font-light ${isIncome ? 'text-income' : 'text-expense'}`}>₹</span>
+              <span className="text-4xl font-light text-white/50">₹</span>
               <input
                 ref={amountRef}
                 type="number"
@@ -79,33 +86,48 @@ export default function AddModal({ open, onClose, onAdd }) {
                 placeholder="0"
                 value={amount}
                 onChange={e => setAmount(e.target.value)}
-                className={`bg-transparent text-5xl font-semibold text-center outline-none w-full max-w-[220px] placeholder-border ${
-                  isIncome ? 'text-income' : 'text-expense'
-                }`}
+                className="bg-transparent text-5xl font-semibold text-center text-white outline-none w-full max-w-[220px] placeholder-border"
               />
             </div>
           </div>
 
-          {/* Date */}
-          <div className="mb-4">
-            <label className="block text-muted text-xs font-medium mb-1 uppercase tracking-wider">Date</label>
-            <input
-              type="date"
-              value={date}
-              onChange={e => setDate(e.target.value)}
-              className="w-full bg-bg border border-border rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-white transition-colors duration-150"
-            />
+          {/* Date — custom picker trigger */}
+          <div className="mb-4 relative">
+            <label className="block text-white/40 text-xs font-medium mb-2 uppercase tracking-wider">Date</label>
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); setCalOpen(v => !v) }}
+              className="w-full glass rounded-xl px-4 py-3 text-white text-sm text-left flex items-center justify-between transition-all duration-150 hover:glass-active"
+            >
+              <span>{formatDisplay(date)}</span>
+              <span className="text-white/40 text-xs">📅</span>
+            </button>
+
+            {/* Calendar popover */}
+            {calOpen && (
+              <div
+                className="absolute left-0 right-0 mt-2 z-10"
+                onClick={e => e.stopPropagation()}
+              >
+                <CalendarPicker
+                  value={date}
+                  onChange={setDate}
+                  onClose={() => setCalOpen(false)}
+                />
+              </div>
+            )}
           </div>
 
           {/* Description */}
-          <div className="mb-6">
-            <label className="block text-muted text-xs font-medium mb-1 uppercase tracking-wider">Description</label>
+          <div className="mb-6" style={{ marginTop: calOpen ? '0' : '0' }}>
+            <label className="block text-white/40 text-xs font-medium mb-2 uppercase tracking-wider">Description</label>
             <input
               type="text"
               placeholder="What was this for?"
               value={description}
               onChange={e => setDescription(e.target.value)}
-              className="w-full bg-bg border border-border rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-white transition-colors duration-150 placeholder-border"
+              onClick={e => { e.stopPropagation(); setCalOpen(false) }}
+              className="w-full glass rounded-xl px-4 py-3 text-white text-sm outline-none transition-all duration-150 placeholder-border focus:glass-active"
             />
           </div>
 
@@ -113,11 +135,7 @@ export default function AddModal({ open, onClose, onAdd }) {
           <button
             type="submit"
             disabled={!amount || parseFloat(amount) <= 0}
-            className={`w-full py-4 rounded-2xl text-base font-semibold transition-all duration-200 active:scale-95 disabled:opacity-30 disabled:cursor-not-allowed ${
-              isIncome
-                ? 'bg-income text-black hover:bg-green-300'
-                : 'bg-expense text-black hover:bg-red-300'
-            }`}
+            className="w-full py-4 rounded-2xl text-base font-semibold transition-all duration-200 active:scale-95 disabled:opacity-25 disabled:cursor-not-allowed glass-active text-white hover:brightness-110"
           >
             Add {type.charAt(0).toUpperCase() + type.slice(1)}
           </button>

--- a/expense-tracker/src/components/BarChart.jsx
+++ b/expense-tracker/src/components/BarChart.jsx
@@ -2,19 +2,18 @@ import { useMemo } from 'react'
 import { getMonthlyTotals, monthShortLabel } from '../utils/format'
 
 const BAR_HEIGHT = 80
-const BAR_WIDTH = 8
-const GAP = 2
-const GROUP_WIDTH = BAR_WIDTH * 2 + GAP + 6
+const BAR_WIDTH = 14
+const GROUP_WIDTH = BAR_WIDTH + 8
 const MONTHS = 12
 
-export default function BarChart({ transactions, activeMonth, year }) {
+export default function BarChart({ transactions, activeMonth, year, activeTab }) {
   const { income, expense } = useMemo(
     () => getMonthlyTotals(transactions, year),
     [transactions, year]
   )
 
-  const maxVal = Math.max(...income, ...expense, 1)
-
+  const values = activeTab === 'income' ? income : expense
+  const maxVal = Math.max(...values, 1)
   const totalWidth = GROUP_WIDTH * MONTHS
   const svgH = BAR_HEIGHT + 24
 
@@ -25,43 +24,30 @@ export default function BarChart({ transactions, activeMonth, year }) {
       style={{ overflow: 'visible' }}
     >
       {Array.from({ length: MONTHS }, (_, i) => {
-        const x = i * GROUP_WIDTH + 3
-        const incH = (income[i] / maxVal) * BAR_HEIGHT
-        const expH = (expense[i] / maxVal) * BAR_HEIGHT
+        const x = i * GROUP_WIDTH + (GROUP_WIDTH - BAR_WIDTH) / 2
+        const h = (values[i] / maxVal) * BAR_HEIGHT
         const isActive = i === activeMonth
-        const incColor = isActive ? '#4ade80' : 'rgba(74,222,128,0.35)'
-        const expColor = isActive ? '#f87171' : 'rgba(248,113,113,0.35)'
+        const fill = isActive ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.18)'
 
         return (
           <g key={i}>
-            {/* income bar */}
             <rect
               x={x}
-              y={BAR_HEIGHT - incH}
+              y={BAR_HEIGHT - h}
               width={BAR_WIDTH}
-              height={incH}
-              rx={3}
-              fill={incColor}
-              style={{ transition: 'height 0.5s ease, y 0.5s ease' }}
+              height={Math.max(h, 2)}
+              rx={4}
+              fill={fill}
+              style={{ transition: 'height 0.5s cubic-bezier(0.34,1.56,0.64,1), y 0.5s cubic-bezier(0.34,1.56,0.64,1)' }}
             />
-            {/* expense bar */}
-            <rect
-              x={x + BAR_WIDTH + GAP}
-              y={BAR_HEIGHT - expH}
-              width={BAR_WIDTH}
-              height={expH}
-              rx={3}
-              fill={expColor}
-              style={{ transition: 'height 0.5s ease, y 0.5s ease' }}
-            />
-            {/* month label */}
             <text
-              x={x + BAR_WIDTH + GAP / 2}
+              x={x + BAR_WIDTH / 2}
               y={BAR_HEIGHT + 16}
               textAnchor="middle"
               fontSize="9"
-              fill={isActive ? '#fff' : '#555'}
+              fill={isActive ? '#fff' : 'rgba(255,255,255,0.3)'}
               fontFamily="Inter, sans-serif"
+              fontWeight={isActive ? '600' : '400'}
             >
               {monthShortLabel(i)}
             </text>

--- a/expense-tracker/src/components/CalendarPicker.jsx
+++ b/expense-tracker/src/components/CalendarPicker.jsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+
+const DAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December']
+
+function parseLocal(str) {
+  const [y, m, d] = str.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+function toStr(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`
+}
+
+export default function CalendarPicker({ value, onChange, onClose }) {
+  const selected = parseLocal(value)
+  const [view, setView] = useState(new Date(selected.getFullYear(), selected.getMonth(), 1))
+
+  const year = view.getFullYear()
+  const month = view.getMonth()
+  const firstDay = new Date(year, month, 1).getDay()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+  const today = toStr(new Date())
+  const cells = []
+  for (let i = 0; i < firstDay; i++) cells.push(null)
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d)
+
+  function prev() { setView(new Date(year, month - 1, 1)) }
+  function next() { setView(new Date(year, month + 1, 1)) }
+
+  function pick(d) {
+    const dateStr = toStr(new Date(year, month, d))
+    onChange(dateStr)
+    onClose()
+  }
+
+  const selStr = toStr(selected)
+
+  return (
+    <div className="glass rounded-2xl p-4 w-full" onClick={e => e.stopPropagation()}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <button
+          type="button"
+          onClick={prev}
+          className="w-8 h-8 flex items-center justify-center rounded-full glass hover:glass-active transition-all text-white/60 hover:text-white text-lg"
+        >
+          ‹
+        </button>
+        <span className="text-white text-sm font-semibold">
+          {MONTHS[month]} {year}
+        </span>
+        <button
+          type="button"
+          onClick={next}
+          className="w-8 h-8 flex items-center justify-center rounded-full glass hover:glass-active transition-all text-white/60 hover:text-white text-lg"
+        >
+          ›
+        </button>
+      </div>
+
+      {/* Day labels */}
+      <div className="grid grid-cols-7 mb-1">
+        {DAYS.map(d => (
+          <div key={d} className="text-center text-white/30 text-xs py-1 font-medium">{d}</div>
+        ))}
+      </div>
+
+      {/* Date grid */}
+      <div className="grid grid-cols-7 gap-y-1">
+        {cells.map((d, i) => {
+          if (!d) return <div key={`e${i}`} />
+          const str = toStr(new Date(year, month, d))
+          const isSelected = str === selStr
+          const isToday = str === today
+          return (
+            <button
+              key={d}
+              type="button"
+              onClick={() => pick(d)}
+              className={`
+                aspect-square flex items-center justify-center rounded-full text-sm transition-all duration-150 mx-auto w-8 h-8
+                ${isSelected
+                  ? 'glass-active text-white font-semibold'
+                  : isToday
+                    ? 'text-white font-medium ring-1 ring-white/20'
+                    : 'text-white/60 hover:text-white hover:glass'
+                }
+              `}
+            >
+              {d}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/expense-tracker/src/components/Header.jsx
+++ b/expense-tracker/src/components/Header.jsx
@@ -1,16 +1,16 @@
 export default function Header({ activeTab, onTabChange }) {
   return (
     <div className="flex items-center justify-center pt-6 pb-4 px-4">
-      <div className="flex bg-surface rounded-full p-1 gap-1">
+      <div className="flex glass rounded-full p-1 gap-1">
         {['expense', 'income'].map(tab => (
           <button
             key={tab}
             onClick={() => onTabChange(tab)}
             className={`
-              px-5 py-2 rounded-full text-sm font-medium transition-all duration-200
+              px-5 py-2 rounded-full text-sm font-medium transition-all duration-250
               ${activeTab === tab
-                ? 'bg-white text-black shadow-sm'
-                : 'text-muted hover:text-white'
+                ? 'glass-active text-white shadow-sm'
+                : 'text-white/40 hover:text-white/70'
               }
             `}
           >

--- a/expense-tracker/src/components/SummaryCard.jsx
+++ b/expense-tracker/src/components/SummaryCard.jsx
@@ -1,12 +1,23 @@
 import { useMemo } from 'react'
 import BarChart from './BarChart'
+import { useCountUp } from '../hooks/useCountUp'
 import {
-  formatCurrencyFull,
   formatCurrency,
   getDelta,
   monthLabel,
   currentMonthYear,
 } from '../utils/format'
+
+function AnimatedAmount({ value }) {
+  const animated = useCountUp(value)
+  const formatted = new Intl.NumberFormat('en-IN', {
+    style: 'currency',
+    currency: 'INR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(animated)
+  return <>{formatted}</>
+}
 
 export default function SummaryCard({ transactions, activeTab }) {
   const { month, year } = currentMonthYear()
@@ -17,32 +28,37 @@ export default function SummaryCard({ transactions, activeTab }) {
   )
 
   const isIncome = activeTab === 'income'
-  const accentColor = isIncome ? 'text-income' : 'text-expense'
-
   const deltaPositive = diff >= 0
-  // For income: more is good (green). For expense: more is bad (red).
   const deltaGood = isIncome ? deltaPositive : !deltaPositive
-  const deltaColor = deltaGood ? 'text-income' : 'text-expense'
   const deltaArrow = deltaPositive ? '↑' : '↓'
-  const deltaLabel = `${deltaArrow} ${formatCurrency(Math.abs(diff))} from last month`
+  const deltaText = diff === 0 ? null : `${deltaArrow} ${formatCurrency(Math.abs(diff))}`
+  // dark green / dark red for delta
+  const deltaStyle = deltaGood
+    ? { color: '#16a34a' }   // dark green
+    : { color: '#b91c1c' }   // dark red
 
   return (
-    <div className="mx-4 mb-2 bg-surface rounded-2xl p-5 overflow-hidden">
+    <div className="mx-4 mb-2 p-5 overflow-hidden">
       {/* Month label */}
-      <p className="text-muted text-sm text-center mb-1">{monthLabel(month, year)}</p>
+      <p className="text-white/40 text-sm text-center mb-1">{monthLabel(month, year)}</p>
 
-      {/* Total amount */}
-      <p className={`text-4xl font-semibold text-center tracking-tight mb-1 ${accentColor}`}>
-        {formatCurrencyFull(current)}
+      {/* Total — white, counter animation */}
+      <p className="text-4xl font-semibold text-center tracking-tight text-white mb-1">
+        <AnimatedAmount value={current} />
       </p>
 
-      {/* Delta */}
-      <p className={`text-sm text-center mb-5 ${diff === 0 ? 'text-muted' : deltaColor}`}>
-        {diff === 0 ? 'No change from last month' : deltaLabel}
+      {/* Delta — small, dark green/red, no "from last month" */}
+      <p className="text-xs text-center mb-5" style={deltaText ? deltaStyle : { color: 'rgba(255,255,255,0.25)' }}>
+        {deltaText ?? '—'}
       </p>
 
-      {/* Bar chart */}
-      <BarChart transactions={transactions} activeMonth={month} year={year} />
+      {/* Bar chart — single type based on active tab */}
+      <BarChart
+        transactions={transactions}
+        activeMonth={month}
+        year={year}
+        activeTab={activeTab}
+      />
     </div>
   )
 }

--- a/expense-tracker/src/hooks/useCountUp.js
+++ b/expense-tracker/src/hooks/useCountUp.js
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react'
+
+export function useCountUp(target, duration = 700) {
+  const [display, setDisplay] = useState(target)
+  const prev = useRef(target)
+  const raf = useRef(null)
+
+  useEffect(() => {
+    const start = prev.current
+    const end = target
+    if (start === end) return
+
+    if (raf.current) cancelAnimationFrame(raf.current)
+    const startTime = performance.now()
+
+    function tick(now) {
+      const elapsed = now - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      const eased = 1 - Math.pow(1 - progress, 3) // easeOutCubic
+      setDisplay(start + (end - start) * eased)
+      if (progress < 1) {
+        raf.current = requestAnimationFrame(tick)
+      } else {
+        setDisplay(end)
+        prev.current = end
+      }
+    }
+
+    raf.current = requestAnimationFrame(tick)
+    return () => { if (raf.current) cancelAnimationFrame(raf.current) }
+  }, [target, duration])
+
+  return display
+}

--- a/expense-tracker/src/index.css
+++ b/expense-tracker/src/index.css
@@ -31,13 +31,6 @@ input[type='number'] { -moz-appearance: textfield; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: #2a2a2a; border-radius: 2px; }
 
-/* Date input styling */
-input[type='date']::-webkit-calendar-picker-indicator {
-  filter: invert(1) opacity(0.4);
-  cursor: pointer;
-}
-input[type='date'] { color-scheme: dark; }
-
 /* Transaction entry animation */
 @keyframes fadeSlideUp {
   from { opacity: 0; transform: translateY(8px); }
@@ -45,4 +38,24 @@ input[type='date'] { color-scheme: dark; }
 }
 
 /* Placeholder color utility */
-.placeholder-border::placeholder { color: #2a2a2a; }
+.placeholder-border::placeholder { color: #333; }
+
+/* Liquid glass */
+.glass {
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+}
+.glass-active {
+  background: rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(28px) saturate(200%);
+  -webkit-backdrop-filter: blur(28px) saturate(200%);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+}
+.glass-modal {
+  background: rgba(14, 14, 14, 0.72);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}


### PR DESCRIPTION
- Remove summary card background (transparent)
- Bar chart now shows only the active tab's data (income or expense)
- Header and modal toggles use Apple-style liquid glass (backdrop-filter blur) instead of solid red/green backgrounds
- Amount uses white color with easeOutCubic counter animation on change
- Delta text simplified: dark green/red, arrow + amount only (no "from last month" copy)
- Add modal sheet uses glassmorphism background, reduced backdrop opacity
- Native date input replaced with custom CalendarPicker popover (glass card, month nav, 7-col day grid, today ring indicator)
- New useCountUp hook for animated number transitions